### PR TITLE
Use data uri scheme for favicon urls

### DIFF
--- a/src/components/Tab.jsx
+++ b/src/components/Tab.jsx
@@ -100,7 +100,7 @@ function Tab({ tab, isHighlighted, onRemove, ...props }) {
   return (
     <Container isHighlighted={isHighlighted} {...props}>
       <FavIcon>
-        {/^https?:\/\//.test(tab.favIconUrl) ? (
+        {/^(https?:\/\/|data:image)/.test(tab.favIconUrl) ? (
           <img src={tab.favIconUrl} alt="" width="100%" height="100%" />
         ) : (
           favIconPlaceholder


### PR DESCRIPTION
The data URI scheme is used by some sites as an img src, including Great Suspender tab favicons (data:image/png;base64,....).  Updated regex to include this scheme